### PR TITLE
Add Clojars embedded widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # luminus-immutant
 
+[![Clojars Project](https://img.shields.io/clojars/v/luminus-immutant.svg)](https://clojars.org/luminus-immutant)
+
 Immutant HTTP adapter for Luminus
 
 ## Usage


### PR DESCRIPTION
Must be pretty handy for quick checking the latest luminus-immutant version without opening Clojars.